### PR TITLE
Fix a broken link to "browser" property

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-The ```browser``` field is provided by a module author as a hint to javascript bundlers or component tools when packaging modules for client side use. The field is found in a ```package.json``` file (described [here](http://browsenpm.org/package.json)) usually located at the root of a project source tree.
+The ```browser``` field is provided by a module author as a hint to javascript bundlers or component tools when packaging modules for client side use. The field is found in a ```package.json``` file (described [here](https://docs.npmjs.com/files/package.json#browser)) usually located at the root of a project source tree.
 
 ## terms
 


### PR DESCRIPTION
The link now points to the npm docs, browser property.